### PR TITLE
Use local publish directory in workflow

### DIFF
--- a/.github/workflows/master_interpret-grading-documents.yml
+++ b/.github/workflows/master_interpret-grading-documents.yml
@@ -27,13 +27,13 @@ jobs:
         run: dotnet build --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o "${{env.DOTNET_ROOT}}/myapp"
+        run: dotnet publish -c Release -o ./publish
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
         with:
           name: .net-app
-          path: ${{env.DOTNET_ROOT}}/myapp
+          path: ./publish
 
   deploy:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary
- publish with `dotnet publish -c Release -o ./publish`
- upload workflow artifact from `./publish`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b04c5a1664832385bb59f3be404071