### PR TITLE
chore: remove dotnet build step from workflow

### DIFF
--- a/.github/workflows/master_interpret-grading-documents.yml
+++ b/.github/workflows/master_interpret-grading-documents.yml
@@ -22,10 +22,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
-
-      - name: Build with dotnet
-        run: dotnet build --configuration Release
-
       - name: dotnet publish
         run: dotnet publish -c Release -o ./publish
 


### PR DESCRIPTION
## Summary
- drop redundant `dotnet build` step from CI so `dotnet publish` handles compilation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b04d88db24832394a42aa1c935cffe